### PR TITLE
remove event listener checks

### DIFF
--- a/src/components/todo-list/todo-list.jsx
+++ b/src/components/todo-list/todo-list.jsx
@@ -10,11 +10,8 @@ export default class TodoList extends HTMLElement {
   connectedCallback() {
     this.render();
 
-    // TODO shim addEventListener in WCC
-    if (document.addEventListener) {
-      document.addEventListener('deleteTodo', (event) => this.deleteTodo(event.detail));
-      document.addEventListener('completeTodo', (event) => this.completeTodo(event.detail));
-    }
+    document.addEventListener('deleteTodo', (event) => this.deleteTodo(event.detail));
+    document.addEventListener('completeTodo', (event) => this.completeTodo(event.detail));
   }
 
   addTodo() {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Latest version of WCC includes [automatic `noop` for event handlers, so need for the check anymore](https://github.com/ProjectEvergreen/wcc/releases)