### PR TITLE
pin Node version for entire project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [16]
+        node: [16.15.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [16]
+        node: [16.15.0]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Tasks to get you going working on this project:
 
 ### Misc
 - Visual Studio Code has [an extension to support lit-html](https://marketplace.visualstudio.com/items?itemName=bierner.lit-html)
+
+test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",
   "engines": {
-    "node": ">=16.15.0"
+    "node": "16.15.0"
   },
   "scripts": {
     "clean": "rimraf ./public ./reports",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #4 , it looks like GitHub Actions is failing due to something (new?) in custom loaders API
```sh
(node:1817) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Error [ERR_LOADER_CHAIN_INCOMPLETE]: "./node_modules/wc-compiler/src/jsx-loader.js 'resolve'" did not call the next hook in its chain and did not explicitly signal a short circuit. If this is intentional, include `shortCircuit: true` in the hook's return.
    at new NodeError (node:internal/errors:387:5)
    at ESMLoader.resolve (node:internal/modules/esm/loader:852:13)
    at async ESMLoader.getModuleJob (node:internal/modules/esm/loader:431:7)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:533:24)
    at async initializeCustomElement (file:///home/runner/work/todo-app/todo-app/node_modules/wc-compiler/src/wcc.js:135:8)
    at async renderFromHTML (file:///home/runner/work/todo-app/todo-app/node_modules/wc-compiler/src/wcc.js:181:5)
    at async executeRouteModule (file:///home/runner/work/todo-app/todo-app/node_modules/@greenwood/cli/src/lib/ssr-route-worker.js:17:[22](https://github.com/thescientist13/todo-app/runs/8164704869?check_suite_focus=true#step:7:23)) {
  code: 'ERR_LOADER_CHAIN_INCOMPLETE'
```

## Summary of Changes
1. [ ] Pin Node version (probably a good idea when using an experimental feature 😅 )